### PR TITLE
fixed wrong logger import in upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed wrong logger import in upgrade.
+  [daniele]
 
 
 2.0.0 (2026-03-26)

--- a/src/collective/z3cform/jsonwidget/upgrades.py
+++ b/src/collective/z3cform/jsonwidget/upgrades.py
@@ -1,6 +1,9 @@
-from collective.editablemenu import logger
 from plone import api
 from plone.base.utils import get_installer
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 default_profile = "profile-collective.z3cform.jsonwidget:default"
 


### PR DESCRIPTION
Fixed wrong logger import in upgrade to remove dependency from "collective.editablemenu".